### PR TITLE
Add Dockerfile for alpine based container

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,31 @@
+FROM alpine
+
+LABEL maintainer="RaBe IT Reaktion <it@rabe.ch>"
+LABEL vendor="Radio Bern RaBe <http://rabe.ch>"
+
+RUN apk add --no-cache \
+    coreutils \
+    m4 \
+    make \
+    musl-dev \
+    opam \
+    pcre-dev \
+    pkgconfig \
+ && adduser -D liquidsoap \
+ && mkdir -p /var/{log/liquidsoap,run/liquidsoap} \
+ && chown liquidsoap /var/{log/liquidsoap,run/liquidsoap}
+
+USER liquidsoap
+
+ENV LS_VERSION 1.4.2
+ENV OCAML_VERSION 4.10.0
+ENV PATH /home/liquidsoap/.opam/${OCAML_VERSION}/bin:${PATH}
+
+RUN opam init --disable-sandboxing --auto-setup \
+ && opam switch create ${OCAML_VERSION} \
+ && opam install --yes liquidsoap.${LS_VERSION} \
+ && opam clean
+
+WORKDIR /var/lib/liquidsoap
+
+ENTRYPOINT ["liquidsoap"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -4,26 +4,33 @@ LABEL maintainer="RaBe IT Reaktion <it@rabe.ch>"
 LABEL vendor="Radio Bern RaBe <http://rabe.ch>"
 
 RUN apk add --no-cache \
+    alsa-lib-dev \
     coreutils \
+    g++ \
+    lame-dev \
+    libmad-dev \
     m4 \
     make \
     musl-dev \
     opam \
     pcre-dev \
     pkgconfig \
+    taglib-dev \
  && adduser -D liquidsoap \
  && mkdir -p /var/{log/liquidsoap,run/liquidsoap} \
  && chown liquidsoap /var/{log/liquidsoap,run/liquidsoap}
 
 USER liquidsoap
 
-ENV LS_VERSION 1.4.2
 ENV OCAML_VERSION 4.10.0
 ENV PATH /home/liquidsoap/.opam/${OCAML_VERSION}/bin:${PATH}
-
 RUN opam init --disable-sandboxing --auto-setup \
  && opam switch create ${OCAML_VERSION} \
- && opam install --yes liquidsoap.${LS_VERSION} \
+ && opam install --yes alsa cry lame mad taglib \
+ && opam clean
+
+ENV LS_VERSION 1.4.2
+RUN opam install --yes liquidsoap.${LS_VERSION} \
  && opam clean
 
 WORKDIR /var/lib/liquidsoap


### PR DESCRIPTION
With an alpine and opam based docker image we can release liquidsoap containers with different versions. With these images we can then set up different checks in [Klangbecken](https://github.com/radiorabe/klangbecken).

After merging I'd like to setup branches with different versions and build them automatically over at [Docker Hub](https://hub.docker.com/r/radiorabe/liquidsoap).

@hairmare: please review and merge if you think this looks fine.